### PR TITLE
Use the ext-calendar polyfill.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         }
     ],
     "require": {
-        "php": ">=5.2"
+        "php": ">=5.2",
+        "fisharebest/ext-calendar": "dev-master"
     },
     "require-dev": {
         "phpunit/phpunit": "4.4.*"

--- a/tests/CalendarTest.php
+++ b/tests/CalendarTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Exception;
 use TenQuality\Utility\Calendar;
 
 /**


### PR DESCRIPTION
## The Problem
PHP  does not innately include ext-calendar. But people want to use this extension regardless.

## The Solution
Use the https://github.com/fisharebest/ext-calendar polyfill. Besides, it has 100% test code coverage and will use `ext-calendar` if it is present on the system.

Also: Fixed a warning in PHPUnit:

`PHP Warning:  The use statement with non-compound name 'Exception' has no effect in /code/contribs/php-calendar/tests/CalendarTest.php on line 3`