### PR TITLE
Use the ext-calendar polyfill.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         }
     ],
     "require": {
-        "php": ">=5.2"
+        "php": ">=5.2",
+        "fisharebest/ext-calendar": "dev-master"
     },
     "require-dev": {
         "phpunit/phpunit": "4.4.*"

--- a/tests/CalendarTest.php
+++ b/tests/CalendarTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Exception;
 use TenQuality\Utility\Calendar;
 
 /**


### PR DESCRIPTION
# The Problem
PHP  does not innately include ext-calendar. But people want to use this extension regardless.

When you do not have `ext-calendar` installed (most instances of PHP, especially dockerized ones, etc.), the library refuses to load and the tests to work:

```
PHP Fatal error:  Uncaught Error: Call to undefined function TenQuality\Utility\cal_days_in_month() in /code/contribs/php-calendar/src/Calendar.php:88
```
Here's the full stack trace:

![image](https://user-images.githubusercontent.com/1125541/57186508-34255880-6ea6-11e9-99e1-ccf1f12e9eaa.png)

If you want people to be able to use your package without `ext-calendar`, then just use the polyfill:

![image](https://user-images.githubusercontent.com/1125541/57186536-836b8900-6ea6-11e9-8d73-a43a440bece2.png)

# The Solution
Use the fisharebest/ext-calendar polyfill. Besides, it has 100% test code coverage and will use `ext-calendar` if it is present on the system.

Also: Fixed a warning in PHPUnit:

`PHP Warning:  The use statement with non-compound name 'Exception' has no effect in /code/contribs/php-calendar/tests/CalendarTest.php on line 3`